### PR TITLE
Update policy's prerequisites check updated

### DIFF
--- a/lib/instance/login_manager.rb
+++ b/lib/instance/login_manager.rb
@@ -43,9 +43,7 @@ module RightScale
     # === Return
     # val(true|false) whether LoginManager works on this platform
     def supported_by_platform?
-      right_platform = RightScale::Platform.linux? || RightScale::Platform.darwin?
-      right_user = user_exists?('rightscale')
-      right_platform && right_user
+      RightScale::Platform.linux? || RightScale::Platform.darwin?
     end
 
     # Enact the login policy specified in new_policy for this system. The policy becomes
@@ -58,7 +56,7 @@ module RightScale
     # === Return
     # description(String) a human-readable description of the update, suitable for auditing
     def update_policy(new_policy)
-      return false unless supported_by_platform?
+      return false unless supported_by_platform? && user_exists?('rightscale')
 
       # As a sanity check, filter out any expired users. The core should never send us these guys,
       # but by filtering here additionally we prevent race conditions and handle boundary conditions, as well

--- a/spec/instance/login_manager_spec.rb
+++ b/spec/instance/login_manager_spec.rb
@@ -153,6 +153,21 @@ describe RightScale::LoginManager do
       end
     end
 
+    context "user 'rightscale' doesn't exist" do
+      before(:each) do
+        flexmock(@mgr).should_receive(:user_exists?).with('rightscale').and_return(false)
+      end
+
+      it "doesn't modify public keys file" do
+        flexmock(@mgr).should_receive(:write_keys_file).never
+        @mgr.update_policy(@policy)
+      end
+
+      it "returns false" do
+        @mgr.update_policy(@policy).should be(false)
+      end
+    end
+
     it "should not add authorized_keys for expired users" do
       @policy.users[0].expires_at = one_day_ago
 


### PR DESCRIPTION
My update fixes LoginManager specs plus it takes out redundant logic from #supported_by_platform? method.
