### PR TITLE
Softlayer userdata 5.7 backport

### DIFF
--- a/clouds/lib/clouds/metadata_sources/config_drive_metadata_source.rb
+++ b/clouds/lib/clouds/metadata_sources/config_drive_metadata_source.rb
@@ -1,0 +1,118 @@
+#
+# Copyright (c) 2011 RightScale Inc
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require File.normalize_path(File.expand_path('../file_metadata_source', __FILE__))
+
+module RightScale
+  module MetadataSources
+    class ConfigDriveMetadataSource < FileMetadataSource
+
+      class ConfigDriveError < Exception; end
+
+      DEFAULT_DEV_DISK_DIR_PATH       = "/dev/disk"
+      DEFAULT_CONFIG_DRIVE_MOUNTPOINT = "/mnt/configdrive"
+
+      attr_accessor :config_drive_label, :config_drive_mountpoint, :config_drive_uuid, :config_drive_filesystem
+
+      def initialize(options)
+        raise ArgumentError, "options[:logger] is required" unless @logger = options[:logger]
+
+        @config_drive_mountpoint      = options[:config_drive_mountpoint] || DEFAULT_CONFIG_DRIVE_MOUNTPOINT
+        @config_drive_uuid            = options[:config_drive_uuid]
+        @config_drive_filesystem      = options[:config_drive_filesystem]
+        @config_drive_label           = options[:config_drive_label]
+
+        if @config_drive_uuid.nil? & @config_drive_label.nil? & @config_drive_filesystem.nil?
+          raise ArgumentError, "at least one of the following is required [options[:config_drive_label], options[:config_drive_filesystem],options[:config_drive_uuid]]"
+        end
+
+        super(options)
+      end
+
+      # Queries for metadata using the given path.
+      #
+      # === Parameters
+      # path(String):: metadata path
+      #
+      # === Return
+      # metadata(String):: query result
+      #
+      # === Raises
+      # QueryFailed:: on any failure to query
+      def query(path)
+        mount_config_drive
+
+        super(path)
+      end
+
+      # Mounts the configuration drive based on the provided parameters
+      #
+      # === Parameters
+      #
+      # === Return
+      # always true
+      #
+      # === Raises
+      # ConfigDriveError:: on failure to find a config drive
+      # SystemCallError:: on failure to create the mountpoint
+      # ArgumentError:: on invalid parameters
+      # VolumeError:: on a failure to mount the device
+      # ParserError:: on failure to parse volume list
+      def mount_config_drive
+        # These two conditions are available on *nix and windows
+        conditions = {}
+        conditions[:label] = @config_drive_label if @config_drive_label
+        conditions[:filesystem] = @config_drive_filesystem if @config_drive_filesystem
+
+        if ::RightScale::Platform.linux? && @config_drive_uuid
+          conditions[:uuid] = @config_drive_uuid
+        end
+
+        timeout   = 60 * 10
+        starttime = Time.now.to_i
+        backoff   = [2,5,10]
+        idx       = -1
+
+        begin
+          device_ary = ::RightScale::Platform.volume_manager.volumes(conditions)
+          idx = idx + 1 unless idx == 2
+          break if (Time.now.to_i - starttime) > timeout || device_ary.length > 0
+          @logger.warn("Configuration drive device was not found.  Trying again in #{backoff[idx % backoff.length]} seconds.")
+          Kernel.sleep(backoff[idx])
+        end while device_ary.length == 0
+
+        # REVIEW: Raise or log and exit?
+        raise ConfigDriveError.new("Configuration drive device found. Conditions: #{conditions.inspect}") if device_ary.length == 0
+
+        FileUtils.mkdir_p(@config_drive_mountpoint) unless File.directory? @config_drive_mountpoint
+
+        if ::RightScale::Platform.linux?
+          ::RightScale::Platform.volume_manager.mount_volume(device_ary[0], @config_drive_mountpoint)
+        elsif ::RightScale::Platform.windows?
+          ::RightScale::Platform.volume_manager.assign_device(device_ary[0][:index], @config_drive_mountpoint)
+        end
+        return true
+      end
+
+    end # ConfigDriveMetadataSource
+  end # MetadataSources
+end # RightScale

--- a/clouds/spec/config_drive_metadata_source_spec.rb
+++ b/clouds/spec/config_drive_metadata_source_spec.rb
@@ -1,0 +1,136 @@
+#
+# Copyright (c) 2011 RightScale Inc
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require File.join(File.dirname(__FILE__), 'spec_helper')
+require File.join(File.dirname(__FILE__), '..', 'lib', 'clouds', 'metadata_sources', 'config_drive_metadata_source')
+require 'json'
+
+module RightScale
+  module ConfigDriveMetadataSourceSpec
+
+    CONFIG_DRIVE_UUID             = "681B-8C5D"
+    CONFIG_DRIVE_FILESYSTEM       = "vfat"
+    CONFIG_DRIVE_LABEL            = "METADATA"
+    CONFIG_DRIVE_DEVICE           = "xvdh1"
+    CONFIG_DRIVE_MOUNTPOINT       = "/tmp/rl_test/mnt/configdrive"
+    USER_METADATA_JSON            = '["RS_rn_url=amqp:\/\/1234567890@broker1-2.rightscale.com\/right_net&RS_rn_id=1234567890&RS_server=my.rightscale.com&RS_rn_auth=1234567890&RS_api_url=https:\/\/my.rightscale.com\/api\/inst\/ec2_instances\/1234567890&RS_rn_host=:1,broker1-1.rightscale.com:0&RS_version=5.6.5&RS_sketchy=sketchy4-2.rightscale.com&RS_token=1234567890"]'
+
+    describe RightScale::MetadataSources::ConfigDriveMetadataSource do
+
+      before(:all) do
+        setup_metadata_provider
+      end
+
+      after(:all) do
+        teardown_metadata_provider
+      end
+
+      def safe_mkdir(dir)
+        if File.directory? dir
+          FileUtils::rm_rf(dir)
+        else
+          FileUtils::mkdir_p(dir)
+        end
+
+      end
+
+      def setup_metadata_provider
+        safe_mkdir(CONFIG_DRIVE_MOUNTPOINT)
+        File.open(File.join(CONFIG_DRIVE_MOUNTPOINT, 'userdata'), 'w') {|f| f.write(USER_METADATA_JSON)}
+
+        # We're just throwing the logs away during tests, could potentially leverage fetch_runner, but it seems
+        # like overkill
+        logger = flexmock("log")
+        logger.should_receive(:debug)
+        logger.should_receive(:error)
+        logger.should_receive(:warn)
+
+        @user_metadata_source = ::RightScale::MetadataSources::ConfigDriveMetadataSource.new({
+          :logger                         => logger,
+          :config_drive_mountpoint        => CONFIG_DRIVE_MOUNTPOINT,
+          :config_drive_uuid              => CONFIG_DRIVE_UUID,
+          :config_drive_filesystem        => CONFIG_DRIVE_FILESYSTEM,
+          :config_drive_label             => CONFIG_DRIVE_LABEL,
+          :user_metadata_source_file_path => File.join(CONFIG_DRIVE_MOUNTPOINT, 'userdata')
+        })
+      end
+
+      def teardown_metadata_provider
+        FileUtils::rm_rf("/tmp/rl_test")
+      end
+
+      context :mount_config_drive do
+        before(:each) do
+          @volume_manager = flexmock("volume_manager")
+          flexmock(::RightScale::Platform).should_receive(:volume_manager).and_return(@volume_manager)
+        end
+
+        it 'raises config_drive_error if no device is found' do
+          timeint = Time.now.to_i
+          @volume_manager.should_receive(:volumes => [])
+          flexmock(Time).should_receive(:now).twice.and_return(timeint, timeint + (60*11))
+
+          lambda { @user_metadata_source.mount_config_drive }.should raise_error(RightScale::MetadataSources::ConfigDriveMetadataSource::ConfigDriveError)
+        end
+
+        it 'creates the config drive mountpoint if it does not exist' do
+          @volume_manager.should_receive(:volumes => [{:device => "/dev/xvda1"}], :mount_volume => true, :assign_device => true)
+
+          flexmock(File).should_receive(:directory?).at_least.once.with(CONFIG_DRIVE_MOUNTPOINT).and_return(false)
+          flexmock(FileUtils).should_receive(:mkdir_p).at_least.once.with(CONFIG_DRIVE_MOUNTPOINT)
+
+          @user_metadata_source.mount_config_drive
+        end
+
+        def test_mount_config_drive
+          flexmock(::RightScale::Platform).should_receive(:linux?).and_return(false)
+          @volume_manager.should_receive(:volumes).times(5).and_return([],[],[],[],[{:device => "/dev/xvdh1"}])
+          flexmock(Kernel).should_receive(:sleep).times(4)
+          @user_metadata_source.mount_config_drive
+        end
+
+        context 'Windows platform' do
+          before(:each) do
+            flexmock(::RightScale::Platform).should_receive(:linux?).and_return(false)
+            flexmock(::RightScale::Platform).should_receive(:windows?).and_return(true)
+          end
+          it 'waits for the config drive to be attached' do
+            @volume_manager.should_receive(:assign_device).once.and_return(true)
+            test_mount_config_drive
+          end
+        end
+
+        context 'Linux platform' do
+          before(:each) do
+            flexmock(::RightScale::Platform).should_receive(:linux?).and_return(true)
+            flexmock(::RightScale::Platform).should_receive(:windows?).and_return(false)
+          end
+          it 'waits for the config drive to be attached' do
+            @volume_manager.should_receive(:mount_volume).once.and_return(true)
+            test_mount_config_drive
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/config/platform/linux.rb
+++ b/config/platform/linux.rb
@@ -166,10 +166,141 @@ module RightScale
 
       # provides utilities for managing volumes (disks).
       class VolumeManager
+
+        class ParserError < Exception; end
+        class VolumeError < Exception; end
+
         def initialize
-          raise "not yet implemented"
         end
-      end
+
+        # Gets a list of currently visible volumes in the form:
+        # [{:device, :label, :uuid, :type, :filesystem}]
+        #
+        # === Parameters
+        # conditions(Hash):: hash of conditions to match, or nil (default)
+        #
+        # === Return
+        # result(Array):: array of volume hashes, or an empty array
+        #
+        # === Raise
+        # VolumeError:: on failure to execute `blkid` to obtain raw output
+        # ParserError:: on failure to parse volume list
+        def volumes(conditions = nil)
+          exit_code, blkid_resp = blocking_popen('blkid')
+          raise VolumeError.new("Failed to list volumes exit code = #{exit_code}\nblkid\n#{blkid_resp}") unless exit_code == 0
+          return parse_volumes(blkid_resp, conditions)
+        end
+
+        # Parses raw output from `blkid` into a hash of volumes
+        #
+        # The hash will contain the device name with a key of :device, and each key value pair
+        # for the device.  In order to keep parity with the Windows VolumeManager.parse_volumes
+        # method, the :type key will be duplicated as :filesystem
+        #
+        # Example of raw output from `blkid`
+        #
+        # /dev/xvdh1: SEC_TYPE="msdos" LABEL="METADATA" UUID="681B-8C5D" TYPE="vfat"
+        # /dev/xvdb1: LABEL="SWAP-xvdb1" UUID="d51fcca0-6b10-4934-a572-f3898dfd8840" TYPE="swap"
+        # /dev/xvda1: UUID="f4746f9c-0557-4406-9267-5e918e87ca2e" TYPE="ext3"
+        # /dev/xvda2: UUID="14d88b9e-9fe6-4974-a8d6-180acdae4016" TYPE="ext3"
+        #
+        # === Parameters
+        # output_text(String):: raw output from `blkid`
+        # conditions(Hash):: hash of conditions to match, or nil (default)
+        #
+        # === Return
+        # result(Array):: array of volume hashes, or an empty array
+        #
+        # === Raise
+        # ParserError:: on failure to parse volume list
+        def parse_volumes(output_text, conditions = nil)
+          results = []
+          output_text.each do |line|
+            volume = {}
+            line_regex = /^([\/a-z0-9]+):(.*)/
+            volmatch = line_regex.match(line)
+            raise ParserError.new("Failed to parse volume info from #{line.inspect} using #{line_regex.inspect}") unless volmatch
+            volume[:device] = volmatch[1]
+            volmatch[2].split(' ').each do |pair|
+              pair_regex = /([a-zA-Z_\-]+)=(.*)/
+              match = pair_regex.match(pair)
+              raise ParserError.new("Failed to parse volume info from #{pair} using #{pair_regex.inspect}") unless match
+              volume[:"#{match[1].downcase}"] = match[2].gsub('"', '')
+              # Make this as much like the windows output as possible
+              if match[1] == "TYPE"
+                volume[:filesystem] = match[2].gsub('"', '')
+              end
+            end
+            if conditions
+              matched = true
+              conditions.each do |key,value|
+
+                unless volume[key] == value
+                  matched = false
+                  break
+                end
+              end
+              results << volume if matched
+            else
+              results << volume
+            end
+          end
+          results
+        end
+
+        # Mounts a volume (returned by VolumeManager.volumes) to the mountpoint specified.
+        #
+        # === Parameters
+        # volume(Hash):: the volume hash returned by VolumeManager.volumes
+        # mountpoint(String):: the exact path where the device will be mounted ex: /mnt
+        #
+        # === Return
+        # always true
+        #
+        # === Raise
+        # ArgumentError:: on invalid parameters
+        # VolumeError:: on a failure to mount the device
+        def mount_volume(volume, mountpoint)
+          raise ArgumentError.new("Invalid volume = #{volume.inspect}") unless volume.is_a?(Hash) && volume[:device]
+          exit_code, mount_list_output = blocking_popen('mount')
+          raise VolumeError.new("Failed interrogation of current mounts; Exit Status: #{exit_code}\nError: #{mount_list_output}") unless exit_code == 0
+
+          device_match = /^#{volume[:device]} on (.+?)\s/.match(mount_list_output)
+          mountpoint_from_device_match = device_match ? device_match[1] : mountpoint
+          unless (mountpoint_from_device_match && mountpoint_from_device_match == mountpoint)
+            raise VolumeError.new("Attempted to mount volume \"#{volume[:device]}\" at \"#{mountpoint}\" but it was already mounted at #{mountpoint_from_device_match}")
+          end
+
+          mountpoint_match = /^(.+?) on #{mountpoint}/.match(mount_list_output)
+          device_from_mountpoint_match = mountpoint_match ? mountpoint_match[1] : volume[:device]
+          unless (device_from_mountpoint_match && device_from_mountpoint_match == volume[:device])
+            raise VolumeError.new("Attempted to mount volume \"#{volume[:device]}\" at \"#{mountpoint}\" but \"#{device_from_mountpoint_match}\" was already mounted there.")
+          end
+
+          # The volume is already mounted at the correct mountpoint
+          return true if /^#{volume[:device]} on #{mountpoint}/.match(mount_list_output)
+
+          # TODO: Maybe validate that the mountpoint is valid *nix path?
+          exit_code, mount_output = blocking_popen("mount -t #{volume[:filesystem].strip} #{volume[:device]} #{mountpoint}")
+          raise VolumeError.new("Failed to mount volume to \"#{mountpoint}\" with device \"#{volume[:device]}\"; Exit Status: #{exit_code}\nError: #{mount_output}") unless exit_code == 0
+          return true
+        end
+
+        # Runs the specified command synchronously using IO.popen
+        #
+        # === Parameters
+        # command(String):: system command to be executed
+        #
+        # === Return
+        # result(Array):: tuple of [exit_code, output_text]
+        def blocking_popen(command)
+          output_text = ""
+          IO.popen(command) do |io|
+            output_text = io.read
+          end
+          return $?.exitstatus, output_text
+        end
+      end # VolumeManager
 
       class Shell
 

--- a/config/spec/linux_volume_manager_spec.rb
+++ b/config/spec/linux_volume_manager_spec.rb
@@ -1,0 +1,181 @@
+#
+# Copyright (c) 2009-2011 RightScale Inc
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+basedir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
+require File.join(basedir, 'spec', 'spec_helper')
+
+if RightScale::Platform.linux?
+  describe RightScale::Platform do
+    before(:all) do
+      @platform = RightScale::Platform
+    end
+
+    context :volume_manager do
+      context :parse_volumes do
+        it 'can parse volumes from blkid output' do
+          blkid_resp = <<EOF
+/dev/xvdh1: SEC_TYPE="msdos" LABEL="METADATA" UUID="681B-8C5D" TYPE="vfat"
+/dev/xvdb1: LABEL="SWAP-xvdb1" UUID="d51fcca0-6b10-4934-a572-f3898dfd8840" TYPE="swap"
+/dev/xvda1: UUID="f4746f9c-0557-4406-9267-5e918e87ca2e" TYPE="ext3"
+/dev/xvda2: UUID="14d88b9e-9fe6-4974-a8d6-180acdae4016" TYPE="ext3"
+EOF
+          volume_hash_ary = [
+            {:device => "/dev/xvdh1", :sec_type => "msdos", :label => "METADATA", :uuid => "681B-8C5D", :type => "vfat", :filesystem => "vfat"},
+            {:device => "/dev/xvdb1", :label => "SWAP-xvdb1", :uuid => "d51fcca0-6b10-4934-a572-f3898dfd8840", :type => "swap", :filesystem => "swap"},
+            {:device => "/dev/xvda1", :uuid => "f4746f9c-0557-4406-9267-5e918e87ca2e", :type => "ext3", :filesystem => "ext3"},
+            {:device => "/dev/xvda2", :uuid => "14d88b9e-9fe6-4974-a8d6-180acdae4016", :type => "ext3", :filesystem => "ext3"}
+          ]
+
+          @platform.volume_manager.parse_volumes(blkid_resp).should == volume_hash_ary
+        end
+
+        it 'raises a parser error when blkid output is malformed' do
+          blkid_resp = 'foobarbz'
+
+          lambda { @platform.volume_manager.parse_volumes(blkid_resp) }.should raise_error(RightScale::Platform::Linux::VolumeManager::ParserError)
+        end
+
+        it 'returns an empty list of volumes when blkid output is empty' do
+          blkid_resp = ''
+
+          @platform.volume_manager.parse_volumes(blkid_resp).should == []
+        end
+
+        it 'can filter results with only one condition' do
+          blkid_resp = <<EOF
+/dev/xvdh1: SEC_TYPE="msdos" LABEL="METADATA" UUID="681B-8C5D" TYPE="vfat"
+/dev/xvdb1: LABEL="SWAP-xvdb1" UUID="d51fcca0-6b10-4934-a572-f3898dfd8840" TYPE="swap"
+/dev/xvda1: UUID="f4746f9c-0557-4406-9267-5e918e87ca2e" TYPE="ext3"
+/dev/xvda2: UUID="14d88b9e-9fe6-4974-a8d6-180acdae4016" TYPE="ext3"
+EOF
+          volume_hash_ary = [
+            {:device => "/dev/xvdh1", :sec_type => "msdos", :label => "METADATA", :uuid => "681B-8C5D", :type => "vfat", :filesystem => "vfat"}
+          ]
+
+          condition = {:uuid => "681B-8C5D"}
+
+          @platform.volume_manager.parse_volumes(blkid_resp, condition).should == volume_hash_ary
+        end
+
+        it 'can filter results with many conditions' do
+          blkid_resp = <<EOF
+/dev/xvdh1: SEC_TYPE="msdos" LABEL="METADATA" UUID="681B-8C5D" TYPE="vfat"
+/dev/xvdb1: LABEL="SWAP-xvdb1" UUID="d51fcca0-6b10-4934-a572-f3898dfd8840" TYPE="swap"
+/dev/xvda1: UUID="f4746f9c-0557-4406-9267-5e918e87ca2e" TYPE="ext3"
+/dev/xvda2: UUID="14d88b9e-9fe6-4974-a8d6-180acdae4016" TYPE="ext3"
+EOF
+          volume_hash_ary = [
+            {:device => "/dev/xvda1", :uuid => "f4746f9c-0557-4406-9267-5e918e87ca2e", :type => "ext3", :filesystem => "ext3"},
+            {:device => "/dev/xvda2", :uuid => "14d88b9e-9fe6-4974-a8d6-180acdae4016", :type => "ext3", :filesystem => "ext3"}
+          ]
+
+          condition = {:filesystem => "ext3"}
+
+          @platform.volume_manager.parse_volumes(blkid_resp, condition).should == volume_hash_ary
+        end
+      end
+
+      context :mount_volume do
+        it 'mounts the specified volume if it is not already mounted' do
+          mount_resp = <<EOF
+/dev/xvda2 on / type ext3 (rw,noatime,errors=remount-ro)
+proc on /proc type proc (rw,noexec,nosuid,nodev)
+EOF
+
+          mount_popen_mock = flexmock(:read => mount_resp)
+          flexmock(IO).should_receive(:popen).with('mount',Proc).once.and_yield(mount_popen_mock)
+          flexmock(IO).should_receive(:popen).with('mount -t vfat /dev/xvdh1 /var/spool/softlayer',Proc).once.and_yield(flexmock(:read => ""))
+
+          @platform.volume_manager.mount_volume({:device => "/dev/xvdh1", :filesystem => "vfat"}, "/var/spool/softlayer")
+        end
+
+        it 'does not attempt to re-mount the volume' do
+          mount_resp = <<EOF
+/dev/xvda2 on / type ext3 (rw,noatime,errors=remount-ro)
+proc on /proc type proc (rw,noexec,nosuid,nodev)
+/dev/xvdh1 on /var/spool/softlayer type vfat (rw) [METADATA]
+EOF
+
+          mount_popen_mock = flexmock(:read => mount_resp)
+          flexmock(IO).should_receive(:popen).with('mount',Proc).once.and_yield(mount_popen_mock)
+          flexmock(IO).should_receive(:popen).with('mount -t vfat /dev/xvdh1 /var/spool/softlayer',Proc).never.and_yield(flexmock(:read => ""))
+
+          @platform.volume_manager.mount_volume({:device => "/dev/xvdh1", :filesystem => "vfat"}, "/var/spool/softlayer")
+        end
+
+        it 'raises argument error when the volume parameter is not a hash' do
+          lambda { @platform.volume_manager.mount_volume("", "") }.should raise_error(ArgumentError)
+        end
+
+        it 'raises argument error when the volume parameter is a hash but does not contain :device' do
+          lambda { @platform.volume_manager.mount_volume({}, "") }.should raise_error(ArgumentError)
+        end
+
+        it 'raises volume error when the device is already mounted to a different mountpoint' do
+          mount_resp = <<EOF
+/dev/xvda2 on / type ext3 (rw,noatime,errors=remount-ro)
+proc on /proc type proc (rw,noexec,nosuid,nodev)
+none on /sys type sysfs (rw,noexec,nosuid,nodev)
+none on /sys/kernel/debug type debugfs (rw)
+none on /sys/kernel/security type securityfs (rw)
+none on /dev type devtmpfs (rw,mode=0755)
+none on /dev/pts type devpts (rw,noexec,nosuid,gid=5,mode=0620)
+none on /dev/shm type tmpfs (rw,nosuid,nodev)
+none on /var/run type tmpfs (rw,nosuid,mode=0755)
+none on /var/lock type tmpfs (rw,noexec,nosuid,nodev)
+none on /lib/init/rw type tmpfs (rw,nosuid,mode=0755)
+/dev/xvda1 on /boot type ext3 (rw,noatime)
+/dev/xvdh1 on /mnt type vfat (rw) [METADATA]
+EOF
+
+          mount_popen_mock = flexmock(:read => mount_resp)
+          flexmock(IO).should_receive(:popen).with('mount',Proc).and_yield(mount_popen_mock)
+
+          lambda { @platform.volume_manager.mount_volume({:device => "/dev/xvdh1"}, "/var/spool/softlayer")}.should raise_error(RightScale::Platform::Linux::VolumeManager::VolumeError)
+        end
+
+        it 'raises volume error when a different device is already mounted to the specified mountpoint' do
+          mount_resp = <<EOF
+/dev/xvda2 on / type ext3 (rw,noatime,errors=remount-ro)
+proc on /proc type proc (rw,noexec,nosuid,nodev)
+none on /sys type sysfs (rw,noexec,nosuid,nodev)
+none on /sys/kernel/debug type debugfs (rw)
+none on /sys/kernel/security type securityfs (rw)
+none on /dev type devtmpfs (rw,mode=0755)
+none on /dev/pts type devpts (rw,noexec,nosuid,gid=5,mode=0620)
+none on /dev/shm type tmpfs (rw,nosuid,nodev)
+none on /var/run type tmpfs (rw,nosuid,mode=0755)
+none on /var/lock type tmpfs (rw,noexec,nosuid,nodev)
+none on /lib/init/rw type tmpfs (rw,nosuid,mode=0755)
+/dev/xvda1 on /boot type ext3 (rw,noatime)
+/dev/xvdh2 on /var/spool/softlayer type vfat (rw) [METADATA]
+EOF
+
+          mount_popen_mock = flexmock(:read => mount_resp)
+          flexmock(IO).should_receive(:popen).with('mount',Proc).and_yield(mount_popen_mock)
+
+          lambda { @platform.volume_manager.mount_volume({:device => "/dev/xvdh1"}, "/var/spool/softlayer")}.should raise_error(RightScale::Platform::Linux::VolumeManager::VolumeError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ported RL 5.8 additions for SoftLayer userdata support.

Note that I'm requesting you pull it to the "package_5.7_sprint30" branch, which is the one that I used as the base for my feature branch.
