### PR TITLE
DEFAULT_THREAD_NAME constant moved, update references.

### DIFF
--- a/actors/instance_scheduler.rb
+++ b/actors/instance_scheduler.rb
@@ -65,7 +65,7 @@ class InstanceScheduler
     unless bundle.executables.empty?
       audit = RightScale::AuditProxy.new(bundle.audit_id)
 
-      if bundle.thread_name == RightScale::ExecutableBundle::DEFAULT_THREAD_NAME
+      if bundle.thread_name == RightScale::AgentConfig.default_thread_name
         on_thread = ''
       else
         on_thread = " on #{bundle.thread_name}"

--- a/lib/instance/cook/cook.rb
+++ b/lib/instance/cook/cook.rb
@@ -90,7 +90,7 @@ module RightScale
     # Determines if the current cook process has the default thread for purposes
     # of concurrency with non-defaulted cooks.
     def has_default_thread?
-      ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME == @thread_name
+      ::RightScale::AgentConfig.default_thread_name == @thread_name
     end
 
     # Helper method to send a request to one or more targets with no response expected

--- a/lib/instance/cook/executable_sequence.rb
+++ b/lib/instance/cook/executable_sequence.rb
@@ -81,8 +81,8 @@ module RightScale
     # === Parameter
     # bundle(RightScale::ExecutableBundle):: Bundle to be run
     def initialize(bundle)
-      unless bundle.thread_name =~ RightScale::ExecutableBundle::VALID_THREAD_NAME
-        raise ArgumentError, "Invalid thread name #{thread_name}"
+      unless bundle.thread_name =~ RightScale::AgentConfig.valid_thread_name
+        raise ArgumentError, "Invalid thread name #{bundle.thread_name.inspect}"
       end
 
       @description            = bundle.to_s

--- a/lib/instance/executable_sequence_proxy.rb
+++ b/lib/instance/executable_sequence_proxy.rb
@@ -51,7 +51,7 @@ module RightScale
     # context(RightScale::OperationContext):: Bundle to be run and associated audit
     def initialize(context, options = {})
       @context = context
-      @thread_name = context.respond_to?(:thread_name) ? context.thread_name : ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME
+      @thread_name = context.respond_to?(:thread_name) ? context.thread_name : ::RightScale::AgentConfig.default_thread_name
       @pid_callback = options[:pid_callback]
       AuditCookStub.instance.setup_audit_forwarding(@thread_name, context.audit)
       AuditCookStub.instance.on_close(@thread_name) { @audit_closed = true; check_done }

--- a/lib/instance/multi_thread_bundle_queue.rb
+++ b/lib/instance/multi_thread_bundle_queue.rb
@@ -165,7 +165,7 @@ module RightScale
     # === Return
     # true:: always true
     def push_to_thread_queue(context)
-      thread_name = context.respond_to?(:thread_name) ? context.thread_name : ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME
+      thread_name = context.respond_to?(:thread_name) ? context.thread_name : ::RightScale::AgentConfig.default_thread_name
       queue = nil
       @mutex.synchronize do
         queue = @thread_name_to_queue[thread_name]

--- a/lib/instance/operation_context.rb
+++ b/lib/instance/operation_context.rb
@@ -46,7 +46,7 @@ module RightScale
       @payload = payload
       @audit = audit
       @decommission = decommission
-      @thread_name = payload.respond_to?(:thread_name) ? payload.thread_name : ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME
+      @thread_name = payload.respond_to?(:thread_name) ? payload.thread_name : ::RightScale::AgentConfig.default_thread_name
     end
 
   end

--- a/lib/instance/single_thread_bundle_queue.rb
+++ b/lib/instance/single_thread_bundle_queue.rb
@@ -30,7 +30,7 @@ module RightScale
     #
     # === Block
     # continuation block
-    def initialize(thread_name = ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME, &continuation)
+    def initialize(thread_name = ::RightScale::AgentConfig.default_thread_name, &continuation)
       super(&continuation)
       @active = false
       @thread = nil

--- a/scripts/bundle_runner.rb
+++ b/scripts/bundle_runner.rb
@@ -83,7 +83,7 @@ module RightScale
     # true:: Always return true
     def run(options, &callback)
       fail('Missing identity or name argument', true) unless options[:id] || options[:name]
-      if options[:thread] && (options[:thread] !~ RightScale::ExecutableBundle::VALID_THREAD_NAME)
+      if options[:thread] && (options[:thread] !~ RightScale::AgentConfig.valid_thread_name)
         fail("Invalid thread name #{options[:thread]}", true)
       end
       echo(options)

--- a/spec/actors/instance_scheduler_spec.rb
+++ b/spec/actors/instance_scheduler_spec.rb
@@ -34,7 +34,7 @@ class ExecutableSequenceMock
   @@last_pid = 100
   def initialize(context, should_fail)
     @context = context
-    @thread_name = context.payload.respond_to?(:thread_name) ? context.payload.thread_name : ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME
+    @thread_name = context.payload.respond_to?(:thread_name) ? context.payload.thread_name : ::RightScale::AgentConfig.default_thread_name
     @should_fail = should_fail
     @pid = @@last_pid += 4
   end

--- a/spec/actors/instantiation_mock.rb
+++ b/spec/actors/instantiation_mock.rb
@@ -49,7 +49,7 @@ module RightScale
       sample_script.attachments  = [sample_attach, sample_attach2]
       sample_script2.attachments = [sample_attach2]
 
-      RightScale::ExecutableBundle.new([sample_script, sample_script2], [], 1234)
+      RightScale::PayloadFactory.make_bundle(:executables => [sample_script, sample_script2])
     end
 
     # Generate array of test software repositories

--- a/spec/instance/audit_cook_stub_spec.rb
+++ b/spec/instance/audit_cook_stub_spec.rb
@@ -32,7 +32,7 @@ describe RightScale::AuditCookStub do
     @thread_names = []
     @forwarded_options = {}
     @thread_count.times do |thread_index|
-      thread_name = (0 == thread_index) ? ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME : "thread ##{thread_index}"
+      thread_name = (0 == thread_index) ? ::RightScale::AgentConfig.default_thread_name : "thread ##{thread_index}"
       auditor = flexmock("auditor for #{thread_name}")
       @auditors << auditor
       RightScale::AuditCookStub.instance.setup_audit_forwarding(thread_name, auditor)

--- a/spec/instance/bundle_queue_spec.rb
+++ b/spec/instance/bundle_queue_spec.rb
@@ -136,7 +136,7 @@ describe RightScale::BundleQueue do
           thread_name ||= name_pair.first
           sequence_name = name_pair.last
         else
-          thread_name ||= ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME
+          thread_name ||= ::RightScale::AgentConfig.default_thread_name
           sequence_name = name_pair.to_s
         end
         names << sequence_name
@@ -186,7 +186,7 @@ describe RightScale::BundleQueue do
       @queue.active?.should be_false
       @queue_closed.should be_false
       @run_sequence_names.empty?.should be_true
-      @required_completion_order.should == { ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME => ['never run by inactive queue'] }
+      @required_completion_order.should == { ::RightScale::AgentConfig.default_thread_name => ['never run by inactive queue'] }
     end
 
     it 'should run all bundles once active' do
@@ -195,7 +195,7 @@ describe RightScale::BundleQueue do
       sequence_count = 4
       thread_name_count.times do |thread_name_index|
         mock_sequence(:count => sequence_count) do |sequence_index|
-          [0 == thread_name_index ? ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME : "thread #{thread_name_index}",
+          [0 == thread_name_index ? ::RightScale::AgentConfig.default_thread_name : "thread #{thread_name_index}",
            "sequence ##{sequence_index + 1}"]
         end
       end
@@ -227,7 +227,7 @@ describe RightScale::BundleQueue do
       @queue_closed.should be_true
       @queue.active?.should be_false
       @run_sequence_names.values.flatten.size.should == 1
-      @required_completion_order.should == { ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME => ['never runs after deactivation'] }
+      @required_completion_order.should == { ::RightScale::AgentConfig.default_thread_name => ['never runs after deactivation'] }
     end
 
     it 'should process the shutdown bundle' do
@@ -236,7 +236,7 @@ describe RightScale::BundleQueue do
       sequence_count = 3
       thread_name_count.times do |thread_name_index|
         mock_sequence(:count => sequence_count) do |sequence_index|
-          [0 == thread_name_index ? ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME : "thread #{thread_name_index}",
+          [0 == thread_name_index ? ::RightScale::AgentConfig.default_thread_name : "thread #{thread_name_index}",
            "sequence ##{sequence_index + 1}"]
         end
       end
@@ -247,7 +247,7 @@ describe RightScale::BundleQueue do
       mock_sequence { 'ignored due to decommissioning and not a decommission bundle' }
       mock_sequence(:decommission => true) { 'decommission bundle' }
       mock_sequence { 'never runs after decommission closes queue' }
-      @required_completion_order[::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME].delete('ignored due to decommissioning and not a decommission bundle')
+      @required_completion_order[::RightScale::AgentConfig.default_thread_name].delete('ignored due to decommissioning and not a decommission bundle')
 
       shutdown_processed = false
       flexmock(@mock_shutdown_request).
@@ -268,8 +268,8 @@ describe RightScale::BundleQueue do
       shutdown_processed.should be_true
       @queue_closed.should be_true
       @run_sequence_names.values.flatten.size.should == count_before_decommission + 1
-      @run_sequence_names[::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME].last.should == 'decommission bundle'
-      @required_completion_order.should == { ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME => ['never runs after decommission closes queue'] }
+      @run_sequence_names[::RightScale::AgentConfig.default_thread_name].last.should == 'decommission bundle'
+      @required_completion_order.should == { ::RightScale::AgentConfig.default_thread_name => ['never runs after decommission closes queue'] }
       @threads_started.size.should == (@multi_threaded ? (thread_name_count + 1) : 1)
     end
 

--- a/spec/instance/cook/executable_sequence_spec.rb
+++ b/spec/instance/cook/executable_sequence_spec.rb
@@ -60,8 +60,14 @@ describe RightScale::ExecutableSequence do
       @script.should_receive(:is_a?).with(RightScale::RightScriptInstantiation).and_return(true)
       @script.should_receive(:is_a?).with(RightScale::RecipeInstantiation).and_return(false)
 
-      @bundle = RightScale::ExecutableBundle.new([ @script ], [], 0, true, [], '', RightScale::DevRepositories.new, nil)
-      @thread_name = RightScale::ExecutableBundle::DEFAULT_THREAD_NAME
+      @bundle = RightScale::PayloadFactory.make_bundle(:executables => [ @script ],
+                                                       :audit_id => 0,
+                                                       :full_converge => true,
+                                                       :cookbooks => [],
+                                                       :repose_servers => '',
+                                                       :dev_cookbooks => RightScale::DevRepositories.new)
+
+      @thread_name = RightScale::AgentConfig.default_thread_name
 
       @auditor = flexmock(RightScale::AuditStub.instance)
       @auditor.should_receive(:create_new_section)
@@ -216,7 +222,7 @@ describe RightScale::ExecutableSequence do
 
       bundle = flexmock('ExecutableBundle')
       bundle.should_receive(:repose_servers).and_return([]).by_default
-      bundle.should_receive(:thread_name).and_return(RightScale::ExecutableBundle::DEFAULT_THREAD_NAME)
+      bundle.should_receive(:thread_name).and_return(RightScale::AgentConfig.default_thread_name)
       bundle.should_ignore_missing
       @sequence = RightScale::ExecutableSequence.new(bundle)
       begin
@@ -266,7 +272,7 @@ describe RightScale::ExecutableSequence do
       bundle = flexmock('ExecutableBundle')
       bundle.should_receive(:repose_servers).and_return([]).by_default
       bundle.should_ignore_missing
-      bundle.should_receive(:thread_name).and_return(RightScale::ExecutableBundle::DEFAULT_THREAD_NAME)
+      bundle.should_receive(:thread_name).and_return(RightScale::AgentConfig.default_thread_name)
       @sequence = RightScale::ExecutableSequence.new(bundle)
     end
 

--- a/spec/instance/cook/external_parameter_gatherer_spec.rb
+++ b/spec/instance/cook/external_parameter_gatherer_spec.rb
@@ -99,7 +99,7 @@ module RightScale
 
     context 'given no credentials' do
       it 'succeeds immediately' do
-        @bundle = ExecutableBundle.new([@script, @recipe], [], 1234)
+        @bundle = RightScale::PayloadFactory.make_bundle(:executables => [@script, @recipe])
         @gatherer = ExternalParameterGatherer.new(@bundle, @options)
         result = run(@gatherer)
         @gatherer.failure_title.should be_nil
@@ -112,7 +112,7 @@ module RightScale
       context 'with no targets' do
         it 'sends requests with no target' do
           script, external_inputs = special_script_with_external_inputs(1, nil)
-          @bundle = ExecutableBundle.new([script], [], 1234)
+          @bundle = RightScale::PayloadFactory.make_bundle(:executables => [script])
           @gatherer = ExternalParameterGatherer.new(@bundle, @options)
 
           nil_targets = {:targets=>nil}
@@ -127,7 +127,7 @@ module RightScale
       context 'with targets specified' do
         it 'sends requests to specific targets' do
           script, external_inputs = special_script_with_external_inputs(1, nil)
-          @bundle = ExecutableBundle.new([script], [], 1234)
+          @bundle = RightScale::PayloadFactory.make_bundle(:executables => [script])
           @gatherer = ExternalParameterGatherer.new(@bundle, @options)
 
           one_target = {:targets=>'rs-steward-12345-1111'}
@@ -142,7 +142,7 @@ module RightScale
       context 'when fatal errors occur' do
         it 'fails RightScripts gracefully' do
           script, external_inputs = special_script_with_external_inputs(3)
-          @bundle = ExecutableBundle.new([script], [], 1234)
+          @bundle = RightScale::PayloadFactory.make_bundle(:executables => [script])
           @gatherer = ExternalParameterGatherer.new(@bundle, @options)
 
           nil_targets = {:targets=>nil}
@@ -172,7 +172,7 @@ module RightScale
 
           recipe, external_inputs = special_recipe_with_external_inputs(3)
 
-          @bundle = ExecutableBundle.new([recipe], [], 1234)
+          @bundle = RightScale::PayloadFactory.make_bundle(:executables => [recipe])
           @gatherer = ExternalParameterGatherer.new(@bundle, @options)
 
           [0, 1].each do |j|
@@ -212,7 +212,7 @@ module RightScale
             recipe.external_inputs[p] = cred
           end
 
-          @bundle = ExecutableBundle.new([@script, @recipe], [], 1234)
+          @bundle = RightScale::PayloadFactory.make_bundle(:executables => [@script, @recipe])
           @bundle.executables << script
           @bundle.executables << recipe
 

--- a/spec/instance/right_scripts_cookbook_spec.rb
+++ b/spec/instance/right_scripts_cookbook_spec.rb
@@ -36,7 +36,7 @@ describe RightScale::RightScriptsCookbook do
     @old_cache_path = RightScale::AgentConfig.cache_dir
     @temp_cache_path = File.join(File.dirname(__FILE__), 'test_cb')
     RightScale::AgentConfig.cache_dir = @temp_cache_path
-    thread_name = RightScale::ExecutableBundle::DEFAULT_THREAD_NAME
+    thread_name = RightScale::AgentConfig.default_thread_name
     @cookbook = RightScale::RightScriptsCookbook.new(thread_name)
   end
 

--- a/spec/instance/spec_helper.rb
+++ b/spec/instance/spec_helper.rb
@@ -31,11 +31,11 @@ shared_examples_for 'mocks cook' do
       attr_accessor :mock_attributes
 
       def initialize
-        @mock_attributes = {:thread_name => ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME}
+        @mock_attributes = {:thread_name => ::RightScale::AgentConfig.default_thread_name}
       end
 
       def has_default_thread?
-        ::RightScale::ExecutableBundle::DEFAULT_THREAD_NAME == @mock_attributes[:thread_name]
+        ::RightScale::AgentConfig.default_thread_name == @mock_attributes[:thread_name]
       end
 
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -237,7 +237,6 @@ module RightScale
         end
       end
     end
-
   end # SpecHelper
 
 end # RightScale
@@ -371,6 +370,35 @@ EOF
   end
 rescue LoadError
   #do nothing; if Chef isn't loaded, then no need to monkey patch
+end
+
+module RightScale
+  class PayloadFactory
+    # build a bundle based on the provided named arguments.  Uses common defaults for some params
+    def self.make_bundle(opts={})
+      defaults = {
+        :executables           => [],
+        :cookbook_repositories => [],
+        :audit_id              => 1234,
+        :full_converge         => nil,
+        :cookbooks             => nil,
+        :repose_servers        => nil,
+        :dev_cookbooks         => nil,
+        :thread_name           => RightScale::AgentConfig.default_thread_name
+      }
+
+      bundle_opts = defaults.merge(opts)
+
+      RightScale::ExecutableBundle.new(bundle_opts[:executables],
+                                       bundle_opts[:cookbook_repositories],
+                                       bundle_opts[:audit_id],
+                                       bundle_opts[:full_converge],
+                                       bundle_opts[:cookbooks],
+                                       bundle_opts[:repose_servers],
+                                       bundle_opts[:dev_cookbooks],
+                                       bundle_opts[:thread_name])
+    end
+  end
 end
 
 shared_examples_for 'mocks state' do


### PR DESCRIPTION
ExecutableBundle payload no longer provides a default for the thread name, so update tests to supply a thread name
