### PR TITLE
Ubuntu 12 dhcp leases file location changed location

### DIFF
--- a/lib/clouds/clouds/cloudstack.rb
+++ b/lib/clouds/clouds/cloudstack.rb
@@ -39,7 +39,7 @@ def dhcp_lease_provider
       sleep 10
     end
   else
-    leases_file = %w{/var/lib/dhcp3/dhclient.eth0.leases /var/lib/dhclient/dhclient-eth0.leases /var/lib/dhclient-eth0.leases}.find{|dhcpconfig| File.exist?(dhcpconfig)}
+    leases_file = %w{/var/lib/dhcp/dhclient.eth0.leases /var/lib/dhcp3/dhclient.eth0.leases /var/lib/dhclient/dhclient-eth0.leases /var/lib/dhclient-eth0.leases}.find{|dhcpconfig| File.exist?(dhcpconfig)}
     unless leases_file.nil?
       lease_file_content = File.read(leases_file)
 


### PR DESCRIPTION
Thile file is needed to query cloudstack metadata
