### PR TITLE
Sl windows userdata fixes - RightLink v5.8 branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ gem "rubyforge",               "1.0.4"
 gem "rake",                    "0.8.7"
 gem "encryptor",               "1.1.3"
 gem "right_support",           "~> 1.4"
-gem "right_agent",             "~> 0.10"
+gem "right_agent",             :git => 'git://github.com/rgeyer/right_agent',
+                               :branch => 'windows_volume_idempotency'
 gem "right_popen",             "~> 1.0"
 gem "right_http_connection",   "~> 1.3"
 gem "right_scraper",           "3.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: git://github.com/rgeyer/right_agent
+  revision: 8efe4ac3673c6c8103d5827f112ebba93fe022e9
+  branch: windows_volume_idempotency
+  specs:
+    right_agent (0.10.8)
+      eventmachine (~> 0.12.10)
+      json (~> 1.4)
+      msgpack (= 0.4.4)
+      net-ssh (~> 2.0)
+      right_amqp (~> 0.3)
+      right_popen (~> 1.0.11)
+      right_support (~> 1.3)
+
 GEM
   remote: http://s3.amazonaws.com/rightscale_rightlink_gems_dev/
   remote: http://rubygems.org/
@@ -81,14 +95,6 @@ GEM
     rbx-require-relative (0.0.9)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    right_agent (0.10.8)
-      eventmachine (~> 0.12.10)
-      json (~> 1.4)
-      msgpack (= 0.4.4)
-      net-ssh (~> 2.0)
-      right_amqp (~> 0.3)
-      right_popen (~> 1.0.11)
-      right_support (~> 1.3)
     right_amqp (0.3.0)
       eventmachine (~> 0.12.10)
       right_support (~> 1.2)
@@ -120,7 +126,7 @@ GEM
       hoe (>= 1.4.0)
     rubyforge (1.0.4)
     stomp (1.1)
-    systemu (2.5.0)
+    systemu (2.5.1)
     treetop (1.4.10)
       polyglot
       polyglot (>= 0.3.1)
@@ -173,7 +179,7 @@ DEPENDENCIES
   process_watcher (= 0.4)
   rake (= 0.8.7)
   rest-client (= 1.6.7)
-  right_agent (~> 0.10)
+  right_agent!
   right_http_connection (~> 1.3)
   right_popen (~> 1.0)
   right_scraper (= 3.0.1)

--- a/lib/clouds/clouds/softlayer.rb
+++ b/lib/clouds/clouds/softlayer.rb
@@ -68,7 +68,7 @@ default_option([:user_metadata, :metadata_tree_climber, :create_leaf_override], 
 default_option([:metadata_source, :user_metadata_source_file_path], File.join(CONFIG_DRIVE_MOUNTPOINT, 'meta.js'))
 
 default_option([:metadata_source, :config_drive_uuid], "681B-8C5D")
-default_option([:metadata_source, :config_drive_filesystem], ::RightScale::Platform.windows? ? 'FAT32' : 'vfat')
+default_option([:metadata_source, :config_drive_filesystem], ::RightScale::Platform.windows? ? 'FAT' : 'vfat')
 default_option([:metadata_source, :config_drive_label], 'METADATA')
 default_option([:metadata_source, :config_drive_mountpoint],  CONFIG_DRIVE_MOUNTPOINT)
 

--- a/lib/clouds/metadata_sources/config_drive_metadata_source.rb
+++ b/lib/clouds/metadata_sources/config_drive_metadata_source.rb
@@ -35,10 +35,10 @@ module RightScale
       def initialize(options)
         super(options)
 
-        @config_drive_mountpoint      = options[:config_drive_mountpoint] || DEFAULT_CONFIG_DRIVE_MOUNTPOINT
-        @config_drive_uuid            = options[:config_drive_uuid]
-        @config_drive_filesystem      = options[:config_drive_filesystem]
-        @config_drive_label           = options[:config_drive_label]
+        @config_drive_mountpoint        = options[:config_drive_mountpoint] || DEFAULT_CONFIG_DRIVE_MOUNTPOINT
+        @config_drive_uuid              = options[:config_drive_uuid]
+        @config_drive_filesystem        = options[:config_drive_filesystem]
+        @config_drive_label             = options[:config_drive_label]
 
         if @config_drive_uuid.nil? & @config_drive_label.nil? & @config_drive_filesystem.nil?
           raise ArgumentError, "at least one of the following is required [options[:config_drive_label], options[:config_drive_filesystem],options[:config_drive_uuid]]"
@@ -90,7 +90,19 @@ module RightScale
         idx       = -1
 
         begin
-          device_ary = ::RightScale::Platform.volume_manager.volumes(conditions)
+          device_ary = []
+          if ::RightScale::Platform.windows?
+            # Check once, in case the metadata drive is onlined already
+            device_ary = ::RightScale::Platform.volume_manager.volumes(conditions)
+            ::RightScale::Platform.volume_manager.disks({:status => "Offline"}).each do |disk|
+              ::RightScale::Platform.volume_manager.online_disk(disk[:index])
+              device_ary = ::RightScale::Platform.volume_manager.volumes(conditions)
+              break if device_ary.length > 0
+              ::RightScale::Platform.volume_manager.offline_disk(disk[:index])
+            end unless device_ary.length > 0
+          else
+            device_ary = ::RightScale::Platform.volume_manager.volumes(conditions)
+          end
           idx = idx + 1 unless idx == 2
           break if (Time.now.to_i - starttime) > timeout || device_ary.length > 0
           @logger.warn("Configuration drive device was not found.  Trying again in #{backoff[idx % backoff.length]} seconds.")
@@ -105,7 +117,7 @@ module RightScale
         if ::RightScale::Platform.linux?
           ::RightScale::Platform.volume_manager.mount_volume(device_ary[0], @config_drive_mountpoint)
         elsif ::RightScale::Platform.windows?
-          ::RightScale::Platform.volume_manager.assign_device(device_ary[0][:index], @config_drive_mountpoint, {:idempotent => true, :clear_readonly => false})
+          ::RightScale::Platform.volume_manager.assign_device(device_ary[0][:index], @config_drive_mountpoint, {:idempotent => true, :clear_readonly => false, :remove_all => true})
         end
         return true
       end


### PR DESCRIPTION
Uses the idempotent option on assign_device in the platform class in RightAgent.  It also cycles through offlined disks on a windows instance looking for the volume matching the specified inputs.

Watch out for Gemfile and Gemfile.lock changes.  A couple gems in Gemfile.lock creeped version due to my local `bundle update` and I am using a specific branch of right_agent from git://github.com/rgeyer/right_agent.git which will need to be built and included

This was actually tracking the master branch of rightscale/right_link, but the only other included commits were ones that are already merged to this branch.
