### PR TITLE
Added a sleep between onlining a windows disk and searching for the meta...

### DIFF
--- a/lib/clouds/metadata_sources/config_drive_metadata_source.rb
+++ b/lib/clouds/metadata_sources/config_drive_metadata_source.rb
@@ -96,6 +96,8 @@ module RightScale
             device_ary = ::RightScale::Platform.volume_manager.volumes(conditions)
             ::RightScale::Platform.volume_manager.disks({:status => "Offline"}).each do |disk|
               ::RightScale::Platform.volume_manager.online_disk(disk[:index])
+              # Per the interwebs, you cannot run disk part commands back to back without a wait.
+              sleep(15)
               device_ary = ::RightScale::Platform.volume_manager.volumes(conditions)
               break if device_ary.length > 0
               ::RightScale::Platform.volume_manager.offline_disk(disk[:index])


### PR DESCRIPTION
...data volume

Some best practice documentation suggests that a wait of 15 seconds between executions of diskpart with a script is necessary.  For now, we'll wait in right_link between critical requests.  Later, we'll have to re-evaluate how we make those requests in right_agent to conform with best practice.
