### PR TITLE
fixed how repose downloader interprets exceptions thrown by latest request balancer from right_support gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,10 +23,10 @@ GIT
 
 GIT
   remote: git://github.com/rightscale/right_support.git
-  revision: 7b03b7a43d7ac7242de6ec0650a1694305eda5e8
+  revision: e844c798d3fe4ad5f223731ac8af4d91c0753a20
   branch: master
   specs:
-    right_support (2.5.5)
+    right_support (2.6.5)
 
 PATH
   remote: .


### PR DESCRIPTION
@ryanwilliamson keep in sync with right_support, parse() is a silly method name for this context
