### PR TITLE
acu92026 - Missing lambda capture in block.

### DIFF
--- a/lib/instance/login_manager.rb
+++ b/lib/instance/login_manager.rb
@@ -126,7 +126,7 @@ module RightScale
       keys = File.readlines(
         File.join(RightScale::Platform.filesystem.ssh_cfg_dir, 'sshd_config')).map do |l|
           key = nil
-          /^\s*HostKey\s+([^ ].*)/.match(l) { key = m.captures[0] }
+          /^\s*HostKey\s+([^ ].*)/.match(l) { |m| key = m.captures[0] }
           key
         end.compact
 


### PR DESCRIPTION
Tony caught a missing capture group for a lambda expression (nice one!). It probably would never get exercised on a real instance unless someone was managing their own server host keys...but it's still a bug.
