### PR TITLE
acu178341 Revert some parts of azure/cloudstack metadata

### DIFF
--- a/lib/chef/ohai/mixin/azure_metadata.rb
+++ b/lib/chef/ohai/mixin/azure_metadata.rb
@@ -85,15 +85,19 @@ module ::Ohai::Mixin::AzureMetadata
   end
 
   def query_url(url)
-    u = URI(url) # doesn't work on 1.8.7 didn't figure out why
-    req = Net::HTTP::Get.new(u.request_uri)
-    req['x-ms-agent-name'] = 'WALinuxAgent'
-    req['x-ms-version'] = '2012-11-30'
+    begin
+      u = URI(url) # doesn't work on 1.8.7 didn't figure out why
+      req = Net::HTTP::Get.new(u.request_uri)
+      req['x-ms-agent-name'] = 'WALinuxAgent'
+      req['x-ms-version'] = '2012-11-30'
 
-    res = Net::HTTP.start(u.hostname, u.port) {|http|
-      http.request(req)
-    }
-    res.body
+      res = Net::HTTP.start(u.hostname, u.port) {|http|
+        http.request(req)
+      }
+      res.body
+    rescue Exception => e
+      ::Ohai::Log.debug("Unable to fetch azure metadata from #{url}: #{e.class}: #{e.message}")
+    end
   end
 
   def fetch_metadata(host)

--- a/lib/chef/ohai/mixin/dhcp_lease_metadata_helper.rb
+++ b/lib/chef/ohai/mixin/dhcp_lease_metadata_helper.rb
@@ -39,7 +39,7 @@ module ::Ohai::Mixin::DhcpLeaseMetadataHelper
   # Searches for a file containing dhcp lease information.
   def dhcp_lease_provider
     if RUBY_PLATFORM =~ /windows|cygwin|mswin|mingw|bccwin|wince|emx/
-      timeout = Time.now + 20 * 60  # 20 minutes
+      timeout = Time.now + 5 * 60  # 5 minutes
       while Time.now < timeout
         ipconfig_data = `ipconfig /all`
         match_result = ipconfig_data.match(/DHCP Server.*\: (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/)
@@ -71,29 +71,4 @@ module ::Ohai::Mixin::DhcpLeaseMetadataHelper
     raise "Cannot determine dhcp lease provider for cloudstack instance"
   end
 
-  def can_metadata_connect?(addr, port, timeout=2)
-    t = Socket.new(Socket::Constants::AF_INET, Socket::Constants::SOCK_STREAM, 0)
-    saddr = Socket.pack_sockaddr_in(port, addr)
-    connected = false
-
-    begin
-      t.connect_nonblock(saddr)
-    rescue Errno::EINPROGRESS
-      r,w,e = IO::select(nil,[t],nil,timeout)
-      if !w.nil?
-        connected = true
-      else
-        begin
-          t.connect_nonblock(saddr)
-        rescue Errno::EISCONN
-          t.close
-          connected = true
-        rescue SystemCallError
-        end
-      end
-    rescue SystemCallError
-    end
-    ::Ohai::Log.debug("can_metadata_connect? == #{connected}")
-    connected
-  end
 end

--- a/lib/chef/plugins/azure.rb
+++ b/lib/chef/plugins/azure.rb
@@ -26,16 +26,17 @@ require 'chef/ohai/mixin/azure_metadata'
 
 extend ::Ohai::Mixin::AzureMetadata
 
-@host = dhcp_lease_provider
-
 def looks_like_azure?
-  looks_like_azure = hint?('azure') && can_metadata_connect?(@host, 80)
+  looks_like_azure = hint?('azure')
   ::Ohai::Log.debug("looks_like_azure? == #{looks_like_azure.inspect}")
   looks_like_azure
 end
 
 
-if looks_like_azure? && (metadata = fetch_metadata(@host))
+if looks_like_azure?
+  metadata = fetch_metadata(dhcp_lease_provider)
   azure Mash.new
-  metadata.each { |k,v| azure[k] = v }
+  if metadata
+    metadata.each { |k,v| azure[k] = v }
+  end
 end

--- a/lib/chef/plugins/cloudstack.rb
+++ b/lib/chef/plugins/cloudstack.rb
@@ -25,16 +25,18 @@ require 'chef/ohai/mixin/cloudstack_metadata'
 
 extend ::Ohai::Mixin::CloudstackMetadata
 
-@host = dhcp_lease_provider
-
 def looks_like_cloudstack?
-  looks_like_cloudstack = hint?('cloudstack') && can_metadata_connect?(@host, 80)
+  looks_like_cloudstack = hint?('cloudstack')
   ::Ohai::Log.debug("looks_like_cloudstack? == #{looks_like_cloudstack.inspect} ")
   looks_like_cloudstack
 end
 
-if looks_like_cloudstack? && (metadata = fetch_metadata(@host))
+if looks_like_cloudstack? 
+  dhcp_ip = dhcp_lease_provider
+  metadata = fetch_metadata(dhcp_ip)
   cloudstack Mash.new
-  metadata.each { |k,v| cloudstack[k] = v }
-  cloudstack['dhcp_lease_provider_ip'] = @host
+  if metadata
+    metadata.each { |k,v| cloudstack[k] = v }
+  end
+  cloudstack['dhcp_lease_provider_ip'] = dhcp_ip
 end

--- a/lib/clouds/clouds/cloudstack.rb
+++ b/lib/clouds/clouds/cloudstack.rb
@@ -38,7 +38,7 @@ end
 
 def dhcp_lease_provider
   if platform.windows?
-    timeout = Time.now + 20 * 60  # 20 minutes
+    timeout = Time.now + 5 * 60  # 5 minutes
     logger = option(:logger)
     while Time.now < timeout
       ipconfig_data = `ipconfig /all`

--- a/spec/chef/ohai/mixin/dhcp_lease_metadata_helper_spec.rb
+++ b/spec/chef/ohai/mixin/dhcp_lease_metadata_helper_spec.rb
@@ -30,10 +30,6 @@ describe ::Ohai::Mixin::DhcpLeaseMetadataHelper do
     mixin
   }
 
-  context 'can_metadata_connect?' do
-    it "should have specs"
-  end
-
   context 'dhcp_lease_provider' do
 
     let(:dhcp_lease_provider_ip) { '1.2.3.4' }

--- a/spec/chef/plugins/azure_spec.rb
+++ b/spec/chef/plugins/azure_spec.rb
@@ -53,7 +53,6 @@ describe Ohai::System, ' plugin azure' do
   # Provide only success scenario, becuase it will be changed in RL 6.1
   it 'populate azure node with required attributes' do
     flexmock(@ohai).should_receive(:hint?).with('azure').and_return({}).once
-    flexmock(@ohai).should_receive(:can_metadata_connect?).with(fetched_dhcp_lease_provider, 80).and_return(true)
     flexmock(@ohai).should_receive(:fetch_metadata).with(fetched_dhcp_lease_provider).and_return(fetched_metadata).once
     @ohai._require_plugin("azure")
     @ohai[:azure].should_not be_nil

--- a/spec/chef/plugins/cloudstack_spec.rb
+++ b/spec/chef/plugins/cloudstack_spec.rb
@@ -46,28 +46,27 @@ describe Ohai::System, ' plugin cloudstack' do
     # ohai to be tested
     @ohai = Ohai::System.new
     flexmock(@ohai).should_receive(:require_plugin).and_return(true)
-    flexmock(@ohai).should_receive(:dhcp_lease_provider).and_return(fetched_dhcp_lease_provider).once
   end
 
   it 'create cloudstack attribute if hint file exists and metadata fetch' do
     flexmock(@ohai).should_receive(:hint?).with('cloudstack').and_return({}).once
-    flexmock(@ohai).should_receive(:can_metadata_connect?).with(fetched_dhcp_lease_provider, 80).and_return(true)
+    flexmock(@ohai).should_receive(:dhcp_lease_provider).and_return(fetched_dhcp_lease_provider).once
     flexmock(@ohai).should_receive(:fetch_metadata).with(fetched_dhcp_lease_provider).and_return(fetched_metadata).once
     @ohai._require_plugin("cloudstack")
     @ohai[:cloudstack].should_not be_nil
     @ohai[:cloudstack].should == fetched_metadata.merge({'dhcp_lease_provider_ip' => fetched_dhcp_lease_provider})
   end
 
-  it 'will not fetch metatada  on non-cloudstack' do
+  it 'will not fetch metatada on non-cloudstack' do
     flexmock(@ohai).should_receive(:hint?).with('cloudstack').and_return(nil).once
     flexmock(@ohai).should_not_receive(:fetch_metadata)
+    flexmock(@ohai).should_not_receive(:dhcp_lease_provider)
     @ohai._require_plugin("cloudstack")
     @ohai[:cloudstack].should be_nil
   end
 
   it 'could not connect to dhcp_lease_provider' do
     flexmock(@ohai).should_receive(:hint?).with('cloudstack').and_return({}).once
-    flexmock(@ohai).should_receive(:can_metadata_connect?).with(fetched_dhcp_lease_provider, 80).and_return(false)
     flexmock(@ohai).should_not_receive(:fetch_metadata)
     @ohai._require_plugin("cloudstack")
     @ohai[:cloudstack].should be_nil
@@ -75,7 +74,6 @@ describe Ohai::System, ' plugin cloudstack' do
 
   it 'will not provide cloudstack node if metatada not exist' do
     flexmock(@ohai).should_receive(:hint?).with('cloudstack').and_return({}).once
-    flexmock(@ohai).should_receive(:can_metadata_connect?).with(fetched_dhcp_lease_provider, 80).and_return(true)
     flexmock(@ohai).should_receive(:fetch_metadata).and_return(nil)
     @ohai._require_plugin("cloudstack")
     @ohai[:cloudstack].should be_nil


### PR DESCRIPTION
Polling for the metadata provider in the root of the plugins was getting
evaluated at load time for the plugins for all clouds. For windows this
included 20 minute waits waiting for it to resolve the DHCP server.
Refactored to only poll for the provider if we're on the right cloud.
