### PR TITLE
acu186104 Bump net-dhcp-ruby to 1.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
     moneta (0.7.20)
     msgpack (0.5.9)
     msgpack (0.5.9-x86-mingw32)
-    net-dhcp (1.3.1)
+    net-dhcp (1.3.2)
     net-http-persistent (2.9.4)
     net-ssh (2.9.1)
     net-ssh-gateway (1.2.0)


### PR DESCRIPTION
v1.3.2 contains a fix to grab the mac address correctly for the dhcp
packet for CentOS 7, which changed its ifconfig output slightly
