### PR TITLE
IV-691 Fix cred parameters to scripts showing up in syslog

### DIFF
--- a/RELEASES.rdoc
+++ b/RELEASES.rdoc
@@ -5,6 +5,7 @@ Released 2014-01-26
 == Bug Fixes
 * Fix for vSphere instances failing to initialize networking.
 * Improve resilience against network connectivity failures when running boot scripts.
+* Remove cred type inputs being logged to syslog for RightScripts and Chef Recipes.
 
 = 6.3.0
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -95,6 +95,11 @@ module RightScale
                    '-b', 60,
                    '-f', 8,
                    '-q',
+                   # This prevents creds from showing up in syslog for any
+                   # any /right_net/scheduler/update_inputs api calls. All API
+                   # requests are logged to syslog for debugging purposes. Pass in
+                   # any sensitive http parameters here.
+                   '-F', "patch",
                    '-S'
                  ]
 

--- a/scripts/agent_deployer.rb
+++ b/scripts/agent_deployer.rb
@@ -89,7 +89,7 @@ module RightScale
       end
 
       opts.on('-F', '--filter-params [PARAMS}') do |params|
-        options[:filter_params] = params.split(/,\s+/)
+        options[:filter_params] = params.split(/\s*,\s*/)
       end
 
       opts.on('--help') do

--- a/scripts/agent_deployer.rb
+++ b/scripts/agent_deployer.rb
@@ -45,6 +45,7 @@
 #                               to ping the RightNet router to check connectivity, 0 means disable ping
 #      --reconnect-interval SEC Set number of seconds between broker reconnect attempts
 #      --offline-queueing, -q   Enable queuing of requests when lose broker connectivity
+#      --filter-params, -F      Set parameters on HTTP requests that are to be hidden when logging
 #      --grace-timeout SEC      Set number of seconds before graceful termination times out
 #      --[no-]dup-check         Set whether to check for and reject duplicate requests, .e.g., due to retries
 #      --options, -o KEY=VAL    Set options that act as final override for any persisted configuration settings
@@ -87,6 +88,10 @@ module RightScale
         options[:offline_queueing] = true
       end
 
+      opts.on('-F', '--filter-params [PARAMS}') do |params|
+        options[:filter_params] = params.split(/,\s+/)
+      end
+
       opts.on('--help') do
         puts Usage.scan(__FILE__)
         exit
@@ -104,6 +109,7 @@ module RightScale
     def configure(options, cfg)
       cfg = super(options, cfg)
       cfg[:offline_queueing] = options[:offline_queueing]
+      cfg[:filter_params] = options[:filter_params]
       cfg
     end
 


### PR DESCRIPTION
API call for /right_net/scheduler/update_inputs was being logged to
syslog with any cred parameters passed to input. Removed logging of
calls parameters